### PR TITLE
slaves[0] is now first slave found (not master)

### DIFF
--- a/src/node-soem-master.cc
+++ b/src/node-soem-master.cc
@@ -204,9 +204,9 @@ class NodeSoemMaster : public Nan::ObjectWrap {
 
             Local<Array> arr = Array::New(isolate);
 
-            int i = 0;
+            int i = 1;
 
-            while (i < ec_slavecount) {
+            while (i <= ec_slavecount) {
             
                 Local<Object> slave = Object::New(isolate);
 
@@ -228,7 +228,7 @@ class NodeSoemMaster : public Nan::ObjectWrap {
 
                 slave->Set(String::NewFromUtf8(isolate, "pdelay"), Uint32::New(isolate, ec_slave[i].pdelay));
 
-                arr->Set(i, slave);
+                arr->Set(i-1, slave);
 
                 i++;
             


### PR DESCRIPTION
I noticed that node-soem could not correctly populate the slaves[0].name field via getSlaves (as well as configaddr, etc.). It seems that your call to getSlaves was referencing ec_slave[i] from 0 to ec_slavecount-1, I have changed this to go from 1 to ec_slavecount and put each slave in slaves[i-1]. I have not tested this on multiple slaves but it works fine for a single slave. I will test on multiple slaves when my next slave device arrives.

- Jonathan